### PR TITLE
Return a single quoted string

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -83,7 +83,7 @@ fi
 #
 ## Create, or update release on Github
 #
-# For a given string return either `null` (if empty), or `"quoted string"` (if not)
+# For a given string return either `null` (if empty), or `'single quoted string'` (if not)
 toJsonOrNull() {
   if [ -z "$1" ]; then
     echo null
@@ -95,7 +95,7 @@ toJsonOrNull() {
     return
   fi
 
-  echo "\"$1\""
+  echo "\'$1\'"
 }
 
 METHOD="POST"


### PR DESCRIPTION
We probably want to return a single quoted string here so any contents is treated as a literal instead of being interpolated.

Fixes #10 

Note: I've only tested this for my use case, so any other testing would be appreciated!