### PR TITLE
Set upload_url output to allow matrices to upload an asset later.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -209,7 +209,9 @@ if [ "$INPUT_ALLOW_OVERRIDE" = "true" ]; then
 fi
 
 
+# Set output URL so matrices can upload an artifact later
 upload_url="$(echo "$releases_url" | sed -e 's|api|uploads|')"
+echo "::set-output name=upload_url::$upload_url"
 
 for asset in "$assets"/*; do
 	file_name="$(basename "$asset")"


### PR DESCRIPTION
Hi :) This looks good, but it's missing this one small feature to be useful as I need to use multiple platforms in a build matrix for a project. Creating a release in each of the matrices doesn't work well, and so this is the best way.