### PR TITLE
Add the generate_release_notes option

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2019 Damian Mee
+Copyright (c) 2022 Ryan Kubiak
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -42,18 +42,19 @@ steps:
 All inputs are available as a _normal_ Action input (set as keys of `with:` map):
 
 
-| name             | required   | description
-|:----------------:|:----------:|----------------
-| `token`          | **always** | Github Access token. Can be accessed using `${{ secrets.GITHUB_TOKEN }}` in the workflow file.
-| `tag`            | sometimes  | If triggered by git tag push, tag is picked up automatically.  Otherwise `tag:` has to be set.
-| `commitish`      | no         | Commit hash this release should point to.  Unnecessary, if `tag` is a git tag.  Otherwise, current `master` is used. [more]
-| `name`           | no         | Name the release, the more creative, the better. Defaults to the name of the tag used. [more]
-| `body`           | no         | Longer description of the release, ex changelog, or info about contributors.  Defaults to the commit message of the reference commit. [more]
-| `draft`          | no         | Set to `true` to create a release, but not publish it. `false` by default. [more]
-| `prerelease`     | no         | Mark this release as a pre-release. `false` by default. [more]
-| `files`          | no         | A **space-separated** list of files to be uploaded. When left empty, no files are uploaded. [More on files below]
-| `gzip`           | no         | Set whether to `gzip` uploaded assets, or not.  Available options are: `true`, `false`, and `folders` which uploads files unchanged, but compresses directories/folders.  Defaults to `true`.  Note: it errors if set to `false`, and `files:` argument contains path to a directory.
-| `allow_override` | no         | Allow override of release, if one with the same tag already exists.  Defaults to `false`
+|           name           | required   | description
+|:------------------------:|:----------:|----------------
+|         `token`          | **always** | Github Access token. Can be accessed using `${{ secrets.GITHUB_TOKEN }}` in the workflow file.
+|          `tag`           | sometimes  | If triggered by git tag push, tag is picked up automatically.  Otherwise `tag:` has to be set.
+|       `commitish`        | no         | Commit hash this release should point to.  Unnecessary, if `tag` is a git tag.  Otherwise, current `master` is used. [more]
+|          `name`          | no         | Name the release, the more creative, the better. Defaults to the name of the tag used. [more]
+|          `body`          | no         | Longer description of the release, ex changelog, or info about contributors.  Defaults to the commit message of the reference commit. [more]
+|         `draft`          | no         | Set to `true` to create a release, but not publish it. `false` by default. [more]
+|       `prerelease`       | no         | Mark this release as a pre-release. `false` by default. [more]
+|         `files`          | no         | A **space-separated** list of files to be uploaded. When left empty, no files are uploaded. [More on files below]
+|          `gzip`          | no         | Set whether to `gzip` uploaded assets, or not.  Available options are: `true`, `false`, and `folders` which uploads files unchanged, but compresses directories/folders.  Defaults to `true`.  Note: it errors if set to `false`, and `files:` argument contains path to a directory.
+|   `allow_override`       | no         | Allow override of release, if one with the same tag already exists.  Defaults to `false`
+| `generate_release_notes` | no         | Whether to automatically generate the name and body for this release. If name is specified, the specified name will be used; otherwise, a name will be automatically generated. If body is specified, the body will be pre-pended to the automatically generated notes.  Defaults to `false` 
 
 [more]: https://developer.github.com/v3/repos/releases/#create-a-release
 [More on files below]: #Files-syntax

--- a/README.md
+++ b/README.md
@@ -1,18 +1,9 @@
-# meeDamian/github-release
+# iamkubi/github-release
 
-[![branches_gh_action_svg]][branches_gh_action_url]
 [![gh_last_release_svg]][gh_last_release_url]
-[![tippin_svg]][tippin_url]
 
-[branches_gh_action_svg]: https://github.com/meeDamian/github-release/workflows/Create%20shortened%20tags/badge.svg
-[branches_gh_action_url]: https://github.com/meeDamian/github-release/blob/master/.github/workflows/on-tag.yml
-
-[gh_last_release_svg]: https://img.shields.io/github/v/release/meeDamian/github-release?sort=semver
-[gh_last_release_url]: https://github.com/meeDamian/github-release/releases/latest
-
-[tippin_svg]: https://img.shields.io/badge/donate-lightning-FDD023?logo=bitcoin&style=flat
-[tippin_url]: https://tippin.me/@meeDamian
-
+[gh_last_release_svg]: https://img.shields.io/github/v/release/iamkubi/github-release?sort=semver
+[gh_last_release_url]: https://github.com/iamkubi/github-release/releases/latest
 
 The sane way of creating new and updating existing Github Releases with assets.
 
@@ -27,7 +18,7 @@ See [action.yml](action.yml)
 steps:
 - uses: actions/checkout@v2
 
-- uses: meeDamian/github-release@2.0
+- uses: iamkubi/github-release@2.0
   with:
     token: ${{ secrets.GITHUB_TOKEN }}
 ```
@@ -123,7 +114,7 @@ with:
 steps:
 - uses: actions/checkout@v2
 
-- uses: meeDamian/github-release@2.0
+- uses: iamkubi/github-release@2.0
   with:
     token: ${{ secrets.GITHUB_TOKEN }}
     tag: ${{ env.MY_CUSTOM_TAG }}
@@ -155,7 +146,7 @@ In practice:
 ```yaml
 # For exact version
 steps:
-  uses: meeDamian/github-release@v2.0.2
+  uses: iamkubi/github-release@v2.0.2
 ```
 
 Or
@@ -163,7 +154,7 @@ Or
 ```yaml
 # For newest minor version 2.0
 steps:
-  uses: meeDamian/github-release@2.0
+  uses: iamkubi/github-release@2.0
 ```
 
 Note: It's likely branches will be deprecated once Github Actions fixes its limitation.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ steps:
         echo ::set-env name=RELEASE_TAG::"v1.0.0"
         echo ::set-env name=RELEASE_NAME::"$GITHUB_WORKFLOW"
 
-    - uses: meeDamian/github-release@2.0
+    - uses: iamkubi/github-release@2.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         tag: ${{ env.RELEASE_TAG }}

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: Github Release create, update, and upload assets
+name: Create GitHub Release
 description: Github Action to create, update, or add files to Github Releases
 author: 'Ryan Kubiak <ryan@kubiq.io>'
 

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: Create GitHub Release
+name: Create a GitHub Release
 description: Github Action to create, update, or add files to Github Releases
 author: 'Ryan Kubiak <ryan@kubiq.io>'
 

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,9 @@
 name: Github Release create, update, and upload assets
 description: Github Action to create, update, or add files to Github Releases
-author: 'Damian Mee <spam@meedamian.com>'
+author: 'Ryan Kubiak <ryan@kubiq.io>'
 
 inputs:
-  # Exposed Github API inputs (identical to ones consumed by Github API):
+  # Exposed GitHub API inputs (identical to ones consumed by Github API):
   #   https://developer.github.com/v3/repos/releases/#create-a-release
   # NOTE: No defaults set for these, to avoid override on update due to the impossibility
   #       of distinguishing between default and user input.

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,13 @@ inputs:
     description: Marks Release as a pre-Release.
     required: false
 
+  generate_release_notes:
+    description: >
+      Whether to automatically generate the name and body for this release. If name is specified, the specified name
+      will be used; otherwise, a name will be automatically generated. If body is specified, the body will be pre-pended
+      to the automatically generated notes.
+    required: false
+
   # Inputs specific to this-action:
   files:
     description: >

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -105,13 +105,14 @@ fi
 #   If POST:  https://developer.github.com/v3/repos/releases/#create-a-release,
 #   If PATCH: https://developer.github.com/v3/repos/releases/#edit-a-release
 status_code="$(jq -nc \
-	--arg tag_name         "$tag" \
-	--arg name             "$INPUT_NAME" \
-	--arg body             "$(printf '%s' "$INPUT_BODY" | sed 's|\\|\\\\|g')" \
-	--arg target_commitish "$INPUT_COMMITISH" \
-	--argjson draft        "${draft:-null}" \
-	--argjson prerelease   "${INPUT_PRERELEASE:-null}" \
-	'{$tag_name, $name, $body, $target_commitish, $draft, $prerelease} | del(.[] | select(. == null or . == ""))' | \
+	--arg tag_name                    "$tag" \
+	--arg name                        "$INPUT_NAME" \
+	--arg body                        "$(printf '%s' "$INPUT_BODY" | sed 's|\\|\\\\|g')" \
+	--arg target_commitish            "$INPUT_COMMITISH" \
+	--argjson draft                   "${draft:-null}" \
+	--argjson prerelease              "${INPUT_PRERELEASE:-null}" \
+	--argjson generate_release_notes  "${INPUT_GENERATE_RELEASE_NOTES:-null}" \
+	'{$tag_name, $name, $body, $target_commitish, $draft, $prerelease, $generate_release_notes} | del(.[] | select(. == null or . == ""))' | \
 	curl -sS -X "$method" -d @- \
 		--write-out "%{http_code}" -o "$TMP/$method.json" \
 		-H "Authorization: token $TOKEN" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -le
 
-PKG="meeDamian/github-release@2.0"
+PKG="iamkubi/github-release@2.0"
 
 #
 ## Input verification


### PR DESCRIPTION
Exposes the create-release option to automatically generate release notes based on contributions.  This interacts well with existing options and won't override anything.