### PR TITLE
Remove deprecated set-env and set-output

### DIFF
--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -20,14 +20,12 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-          echo "::set-env name=TAG::${GITHUB_REF#refs/tags/}"
-
       - name: Create, or update the short-name branch
-        if: startsWith(env.TAG, 'v0.0') != true
+        if: startsWith(github.ref_name, 'v0.0') != true
         run: |
-          SHORT="$(echo "${TAG#v}" | cut -d. -f-2)"
+          SHORT="$(echo "${GITHUB_REF_NAME#v}" | cut -d. -f-2)"
 
-          git branch -f "$SHORT" "$TAG"
+          git branch -f "$SHORT" "$GITHUB_REF_NAME"
 
           git push --force \
             "https://$GITHUB_ACTOR:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY.git" \

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ steps:
     ...
     - name: Set enviroment for github-release
       run: |
-        echo ::set-env name=RELEASE_TAG::"v1.0.0"
-        echo ::set-env name=RELEASE_NAME::"$GITHUB_WORKFLOW"
+        echo "RELEASE_TAG=v1.0.0" >> $GITHUB_ENV
+        echo "RELEASE_NAME=$GITHUB_WORKFLOW" >> $GITHUB_ENV
 
     - uses: meeDamian/github-release@2.0
       with:
@@ -79,9 +79,9 @@ steps:
     ...
 ```
 
-To learn more about notation used above see [this].
+To learn more about the use of `GITHUB_ENV` above see [this].
 
-[this]: https://help.github.com/en/articles/development-tools-for-github-actions#set-an-environment-variable-set-env
+[this]: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
 
 
 #### Files syntax

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -129,7 +129,7 @@ fi
 release_id="$(jq '.id' < "$TMP/$method.json")"
 
 # Make release ID available to other steps in user's workflow
-echo "::set-output name=release_id::$release_id"
+echo "release_id=$release_id" >> $GITHUB_OUTPUT
 echo "::endgroup::"
 
 #


### PR DESCRIPTION
The `set-env` and `set-output` commands have been deprecated. `set-output` is due to be removed in June 2023.
See these blog posts:
* https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
* https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

The replacement is the use of the `GITHUB_ENV` and `GITHUB_OUTPUT` [environment files](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files).

The current tag name is also now available via `GITHUB_REF_NAME` or `github.ref_name`, as appropriate.