### PR TITLE
Fixed file parameter that has strings with spaces - Parsing Issue

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -147,8 +147,9 @@ assets="$HOME/assets"
 mkdir -p "$assets/"
 
 
-# This loop splits files on space
-for entry in $INPUT_FILES; do
+# This loop splits files on newlines
+IFS='
+' && for entry in $INPUT_FILES; do
 	# Well, that needs explaining…  If delimiter given in `-d` does not occur in string, `cut` always returns
 	#   the original string, no matter what the field `-f` specifies.
 	#


### PR DESCRIPTION
As per this open Issue: https://github.com/meeDamian/github-release/issues/33

I commented the following solution:
https://github.com/meeDamian/github-release/issues/33#issuecomment-1823420056

On the entrypoint.sh script, the files are evaluated within a loop:
`for entry in $INPUT_FILES; do`

This has the unfortunate outcome of splitting strings via spaces, BUT you can change the way it should split by updating the Internal Field Separator.
So the solution is:
```
IFS='
' && for entry in $INPUT_FILES; do
```
![image](https://github.com/meeDamian/github-release/assets/56458442/4410ec90-4b11-41c3-a76f-1bb32c25c6ab)

